### PR TITLE
Fix/poll and survey pr

### DIFF
--- a/app/course/[course_id]/manage/surveys/[survey_id]/edit/page.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/edit/page.tsx
@@ -41,10 +41,9 @@ export default function EditSurveyPage() {
   const { course_id, survey_id } = useParams();
   const router = useRouter();
   const trackEvent = useTrackEvent();
-  const { private_profile_id } = useClassProfiles();
+  const { private_profile_id, role } = useClassProfiles();
   const [isLoading, setIsLoading] = useState(true);
   const [surveyData, setSurveyData] = useState<SurveyRow>();
-  const { role } = useClassProfiles();
   const rawSurveyId = getParam(survey_id, "survey_id");
   const timezone = role.classes?.time_zone || "America/New_York";
 

--- a/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/responses/SurveyResponsesView.tsx
@@ -86,14 +86,22 @@ function formatResponseValue(value: unknown): string {
   return String(value);
 }
 
-function escapeCSVValue(value: string): string {
+function escapeCSVValue(value: unknown): string {
   if (value === null || value === undefined) {
     return "";
   }
 
   const stringValue = String(value);
 
-  // if string value contains comma, quote, or newline, wrap in quotes and escape internal quotes
+  // Prevent CSV/Excel formula injection (OWASP/CWE-1236)
+  // Characters =, +, -, @ at the start can be interpreted as formulas
+  const trimmed = stringValue.trimStart();
+  if (["=", "+", "-", "@"].includes(trimmed[0] ?? "")) {
+    // Leading apostrophe forces text interpretation in spreadsheet applications
+    return `"'${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  // If string value contains comma, quote, or newline, wrap in quotes and escape internal quotes
   if (stringValue.includes(",") || stringValue.includes('"') || stringValue.includes("\n")) {
     return `"${stringValue.replace(/"/g, '""')}"`;
   }

--- a/app/course/[course_id]/manage/surveys/new/page.tsx
+++ b/app/course/[course_id]/manage/surveys/new/page.tsx
@@ -27,7 +27,6 @@ type SurveyFormData = {
 };
 
 type SurveyStatus = Tables<"surveys">["status"]; // "draft" | "published" | "closed"
-type SurveyIds = Pick<Tables<"surveys">, "id" | "survey_id">;
 
 export default function NewSurveyPage() {
   const { course_id } = useParams();
@@ -296,8 +295,7 @@ export default function NewSurveyPage() {
           .update(updatePayload)
           .eq("id", currentSurveyId)
           .select("id, survey_id")
-          .single()
-          .returns<SurveyIds>();
+          .single();
 
         data = result.data;
         error = result.error;
@@ -311,8 +309,7 @@ export default function NewSurveyPage() {
           .eq("created_by", private_profile_id)
           .order("created_at", { ascending: false })
           .limit(1)
-          .single()
-          .returns<SurveyIds>();
+          .single();
 
         if (existingSurvey && !surveyError) {
           // Update existing survey found by query
@@ -335,8 +332,7 @@ export default function NewSurveyPage() {
             .update(updatePayload)
             .eq("id", existingSurvey.id)
             .select("id, survey_id")
-            .single()
-            .returns<SurveyIds>();
+            .single();
 
           data = result.data;
           error = result.error;
@@ -363,8 +359,7 @@ export default function NewSurveyPage() {
             .from("surveys")
             .insert(insertPayload)
             .select("id, survey_id")
-            .single()
-            .returns<SurveyIds>();
+            .single();
 
           data = result.data;
           error = result.error;
@@ -394,8 +389,7 @@ export default function NewSurveyPage() {
           .from("surveys")
           .insert(insertPayload)
           .select("id, survey_id")
-          .single()
-          .returns<SurveyIds>();
+          .single();
 
         data = result.data;
         error = result.error;


### PR DESCRIPTION
This PR fixes and cleans up several issues related to polls and surveys, focusing on hook consolidation, removing deprecated patterns, and improving security around CSV exports.

Changes

Refactored poll logic to use the shared useClassProfiles hook
Removed deprecated .returns() calls from the survey creation page
Prevented CSV formula injection in survey response exports
Consolidated duplicate useClassProfiles hooks and removed risky survey code paths