### PR TITLE
Restore is_submitted and deleted_at filters on survey responses query…

### DIFF
--- a/app/course/[course_id]/manage/surveys/[survey_id]/responses/page.tsx
+++ b/app/course/[course_id]/manage/surveys/[survey_id]/responses/page.tsx
@@ -65,10 +65,9 @@ export default async function SurveyResponsesPage({ params }: SurveyResponsesPag
       )
     `
     )
-    .eq("survey_id", survey.id);
-  // Use the database ID of the latest survey version to fetch responses
-  // .eq("is_submitted", true); // Temporarily comment out to test if this column exists
-  // .is("deleted_at", null); // Temporarily comment out to test if this column exists
+    .eq("survey_id", survey.id)
+    .eq("is_submitted", true)
+    .is("deleted_at", null);
 
   if (responsesError) {
     console.error("Error fetching responses:", responsesError);


### PR DESCRIPTION
… (Fixes #97)

  The query had debug-commented filters that could expose draft and
  soft-deleted responses to instructors. Restored the filters to only
  return submitted, non-deleted responses.