### PR TITLE
updated filter label to available

### DIFF
--- a/app/course/[course_id]/surveys/page.tsx
+++ b/app/course/[course_id]/surveys/page.tsx
@@ -177,7 +177,7 @@ export default function StudentSurveysPage() {
   const filterOptions = useMemo(
     () => [
       { value: "all" as const, label: "All" },
-      { value: "not_started" as const, label: "Not Started" },
+      { value: "not_started" as const, label: "Available" },
       { value: "completed" as const, label: "Completed" }
     ],
     []


### PR DESCRIPTION
Updated filter label in `app/course/[course_id]/surveys/page.tsx` (line 180)
- Changed label from "Not Started" to "Available"
- Filter logic remains unchanged (still shows `not_started` OR `in_progress` surveys)